### PR TITLE
UI and logic for switching between school-types in public routes

### DIFF
--- a/public/blue_triangle.svg
+++ b/public/blue_triangle.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 100 100" version="1.1" preserveAspectRatio="none"
+  xmlns="http://www.w3.org/2000/svg">
+  <path d="M0 0 L50 100 L100 0 Z" fill="#155dfc"></path>
+</svg>

--- a/src/app/(public)/data/page.tsx
+++ b/src/app/(public)/data/page.tsx
@@ -16,22 +16,26 @@ import {
   ChevronLeftIcon,
 } from "@heroicons/react/24/outline";
 import Link from "next/link";
-import  PublicSwitchButton  from "@/components/buttons/PublicSwitchButton";
+import PublicSwitchButton from "@/components/buttons/PublicSwitchButton";
 
-export default async function DataPage() {
+export default async function DataPage({
+  searchParams,
+}: {
+  searchParams: { type?: string };
+}) {
+  const { type } = await searchParams;
+
+  const selectedType =
+    type === "ms" ? SchoolType.Kindergarten : SchoolType.Elementary;
+
   const { founders, ordinances } = await api.withRemult(async () => {
-    const cities = await CityController.loadPublishedCities(
-      SchoolType.Elementary
-    );
+    const cities = await CityController.loadPublishedCities(selectedType);
     const ordinances = await CityController.loadActiveOrdinancesByCityCodes(
       cities.map((f) => f.code),
-      SchoolType.Elementary
+      selectedType
     );
     return { founders: cities, ordinances };
   });
-
-
-
 
   return (
     <div className="container mx-auto py-12 px-4">
@@ -51,7 +55,7 @@ export default async function DataPage() {
           jejich spádovým školám.
         </p>
         <div className="w-fit">
-        <PublicSwitchButton />
+          <PublicSwitchButton />
         </div>
       </div>
 

--- a/src/app/(public)/data/page.tsx
+++ b/src/app/(public)/data/page.tsx
@@ -18,12 +18,11 @@ import {
 import Link from "next/link";
 import PublicSwitchButton from "@/components/buttons/PublicSwitchButton";
 
-export default async function DataPage({
-  searchParams,
-}: {
-  searchParams: { type?: string };
+export default async function DataPage(props: {
+  searchParams: Promise<{ [key: string]: string | undefined }>;
 }) {
-  const { type } = await searchParams;
+  const searchParams = await props.searchParams;
+  const { type } = searchParams;
 
   const selectedType =
     type === "ms" ? SchoolType.Kindergarten : SchoolType.Elementary;

--- a/src/app/(public)/data/page.tsx
+++ b/src/app/(public)/data/page.tsx
@@ -16,7 +16,7 @@ import {
   ChevronLeftIcon,
 } from "@heroicons/react/24/outline";
 import Link from "next/link";
-import PublicSwitchButton from "@/components/buttons/PublicSwitchButton";
+import { PublicSwitchButton } from "@/components/buttons/PublicSwitchButton";
 
 export default async function DataPage(props: {
   searchParams: Promise<{ [key: string]: string | undefined }>;

--- a/src/app/(public)/embed/Embed.tsx
+++ b/src/app/(public)/embed/Embed.tsx
@@ -16,7 +16,7 @@ import Link from "next/link";
 import { useState } from "react";
 import { AcademicCapIcon, PuzzlePieceIcon } from "@heroicons/react/24/solid";
 import { SchoolType } from "@/types/basicTypes";
-import SwitchButton from "@/components/buttons/SwitchButton";
+import { SwitchButton } from "@/components/buttons/SwitchButton";
 import { useMemo } from "react";
 import { getRootPathBySchoolType } from "@/entities/School";
 

--- a/src/app/(public)/embed/Embed.tsx
+++ b/src/app/(public)/embed/Embed.tsx
@@ -93,14 +93,20 @@ export default function Embed({ schools, cities }: MunicipalityPageProps) {
           <Label>Typ školy?</Label>
           <div className="w-fit">
             <SwitchButton
-              leftLabel={texts.schoolsKindergarten}
-              leftIcon={PuzzlePieceIcon}
-              rightLabel={texts.schoolsElementary}
-              rightIcon={AcademicCapIcon}
+              segments={[
+                {
+                  label: texts.schoolsKindergarten,
+                  icon: PuzzlePieceIcon,
+                  value: SchoolType.Kindergarten,
+                },
+                {
+                  label: texts.schoolsElementary,
+                  icon: AcademicCapIcon,
+                  value: SchoolType.Elementary,
+                },
+              ]}
               defaultValue={schoolType}
-              leftValue={SchoolType.Kindergarten}
-              rightValue={SchoolType.Elementary}
-              onValueChange={(value) => setSchoolType(value)}
+              onValueChange={setSchoolType}
             />
           </div>
 

--- a/src/app/(public)/embed/Embed.tsx
+++ b/src/app/(public)/embed/Embed.tsx
@@ -55,7 +55,7 @@ export default function Embed({ schools, cities }: MunicipalityPageProps) {
     }));
     setSchoolIzo(filtered[0]?.schools[0]?.izo);
     return filtered;
-  }, [schoolType]);
+  }, [schools, schoolType]);
 
   const handlePageTypeChange = (value: string) => {
     const pageType = value as PageType;

--- a/src/app/(public)/embed/Embed.tsx
+++ b/src/app/(public)/embed/Embed.tsx
@@ -93,9 +93,9 @@ export default function Embed({ schools, cities }: MunicipalityPageProps) {
           <Label>Typ školy?</Label>
           <div className="w-fit">
             <SwitchButton
-              leftLabel="Mateřské Školy"
+              leftLabel={texts.schoolsKindergarten}
               leftIcon={PuzzlePieceIcon}
-              rightLabel="Základní Školy"
+              rightLabel={texts.schoolsElementary}
               rightIcon={AcademicCapIcon}
               defaultValue={schoolType}
               leftValue={SchoolType.Kindergarten}

--- a/src/app/(public)/embed/page.tsx
+++ b/src/app/(public)/embed/page.tsx
@@ -5,8 +5,8 @@ import Embed from "./Embed";
 
 export default async function EmbedPage() {
   const { cities, schools } = await api.withRemult(async () => ({
-    cities: await CityController.loadPublishedCities(SchoolType.Elementary),
-    schools: await CityController.loadPublishedSchools(SchoolType.Elementary),
+    cities: await CityController.loadPublishedCities(),
+    schools: await CityController.loadPublishedSchools(),
   }));
 
   return <Embed schools={schools} cities={cities} />;

--- a/src/components/buttons/PublicSwitchButton.tsx
+++ b/src/components/buttons/PublicSwitchButton.tsx
@@ -1,24 +1,44 @@
 "use client";
 
-import Spinner from "@/components/common/Spinner";
 import dynamic from "next/dynamic";
 import { useMemo } from "react";
-
 import { SchoolType } from "@/types/basicTypes";
-import  SwitchButton  from "@/components/buttons/SwitchButton";
-import {
-  AcademicCapIcon,
-  PuzzlePieceIcon,
-} from "@heroicons/react/24/solid";
+import { AcademicCapIcon, PuzzlePieceIcon } from "@heroicons/react/24/solid";
+import { useRouter } from "next/navigation";
+import { texts } from "@/utils/shared/texts";
 
 export default function PublicSwitchButton() {
+  const router = useRouter();
+  const onValueChange = (value: SchoolType) => {
+    const paramVal = value === SchoolType.Kindergarten ? "ms" : "zs";
+    router.push(`?type=${paramVal}`);
+  };
+
   const Btn = useMemo(
     () =>
       dynamic(() => import("@/components/buttons/SwitchButton"), {
+        loading: () => (
+          <div
+            className={
+              "flex justify-center items-center gap-2 py-1 px-2 bg-gray-300 h-[50px] animate-pulse w-[280px] rounded-[6px]"
+            }
+          ></div>
+        ),
         ssr: false,
       }),
     []
   );
 
-  return <Btn leftLabel="Mateřské Školy" leftIcon={PuzzlePieceIcon} rightLabel="Základní Školy" rightIcon={AcademicCapIcon} leftValue={SchoolType.Kindergarten} rightValue={SchoolType.Elementary} />;
+  return (
+    <Btn
+      leftLabel={texts.schoolsKindergarten}
+      leftIcon={PuzzlePieceIcon}
+      rightLabel={texts.schoolsElementary}
+      rightIcon={AcademicCapIcon}
+      defaultValue={SchoolType.Elementary}
+      leftValue={SchoolType.Kindergarten}
+      rightValue={SchoolType.Elementary}
+      onValueChange={(value) => onValueChange(value)}
+    />
+  );
 }

--- a/src/components/buttons/PublicSwitchButton.tsx
+++ b/src/components/buttons/PublicSwitchButton.tsx
@@ -7,7 +7,7 @@ import { AcademicCapIcon, PuzzlePieceIcon } from "@heroicons/react/24/solid";
 import { useRouter } from "next/navigation";
 import { texts } from "@/utils/shared/texts";
 
-export default function PublicSwitchButton() {
+export function PublicSwitchButton() {
   const router = useRouter();
   const onValueChange = (value: SchoolType) => {
     const paramVal = value === SchoolType.Kindergarten ? "ms" : "zs";

--- a/src/components/buttons/PublicSwitchButton.tsx
+++ b/src/components/buttons/PublicSwitchButton.tsx
@@ -31,14 +31,20 @@ export default function PublicSwitchButton() {
 
   return (
     <Btn
-      leftLabel={texts.schoolsKindergarten}
-      leftIcon={PuzzlePieceIcon}
-      rightLabel={texts.schoolsElementary}
-      rightIcon={AcademicCapIcon}
+      segments={[
+        {
+          label: texts.schoolsKindergarten,
+          icon: PuzzlePieceIcon,
+          value: SchoolType.Kindergarten,
+        },
+        {
+          label: texts.schoolsElementary,
+          icon: AcademicCapIcon,
+          value: SchoolType.Elementary,
+        },
+      ]}
       defaultValue={SchoolType.Elementary}
-      leftValue={SchoolType.Kindergarten}
-      rightValue={SchoolType.Elementary}
-      onValueChange={(value) => onValueChange(value)}
+      onValueChange={onValueChange}
     />
   );
 }

--- a/src/components/buttons/PublicSwitchButton.tsx
+++ b/src/components/buttons/PublicSwitchButton.tsx
@@ -6,6 +6,7 @@ import { SchoolType } from "@/types/basicTypes";
 import { AcademicCapIcon, PuzzlePieceIcon } from "@heroicons/react/24/solid";
 import { useRouter } from "next/navigation";
 import { texts } from "@/utils/shared/texts";
+import { SwitchButton } from "@/components/buttons/SwitchButton";
 
 export function PublicSwitchButton() {
   const router = useRouter();
@@ -14,23 +15,8 @@ export function PublicSwitchButton() {
     router.push(`?type=${paramVal}`);
   };
 
-  const Btn = useMemo(
-    () =>
-      dynamic(() => import("@/components/buttons/SwitchButton"), {
-        loading: () => (
-          <div
-            className={
-              "flex justify-center items-center gap-2 py-1 px-2 bg-gray-300 h-[50px] animate-pulse w-[280px] rounded-[6px]"
-            }
-          ></div>
-        ),
-        ssr: false,
-      }),
-    []
-  );
-
   return (
-    <Btn
+    <SwitchButton
       segments={[
         {
           label: texts.schoolsKindergarten,

--- a/src/components/buttons/SwitchButton.tsx
+++ b/src/components/buttons/SwitchButton.tsx
@@ -9,7 +9,7 @@ export type Segment = {
   value: any;
 };
 
-export default function SwitchButton({
+export function SwitchButton({
   segments = [],
   defaultValue = segments[0]?.value,
   onValueChange,

--- a/src/components/buttons/SwitchButton.tsx
+++ b/src/components/buttons/SwitchButton.tsx
@@ -18,19 +18,25 @@ export function SwitchButton({
   defaultValue?: SchoolType;
   onValueChange?: (value: any) => void;
 }) {
+  const handleValueChange = (value: string) => {
+    if (onValueChange) {
+      onValueChange(Number(value) as SchoolType);
+    }
+  };
+
   return (
     <Tabs
       defaultValue={String(defaultValue)}
-      onValueChange={onValueChange}
+      onValueChange={handleValueChange}
       className="h-[50px] w-full "
     >
       <TabsList className="h-full p-[5px] w-full border border-gray-300 rounded-md">
         {segments.map((segment, idx) => {
           const Icon = segment.icon;
-          const colors = ["#155dfc", "#03b703"];
-          const activeBg = `data-[state=active]:bg-[${
-            colors[idx % colors.length]
-          }]`;
+          const activeBg =
+            idx % 2 === 1
+              ? `data-[state=active]:bg-[#03b703]`
+              : `data-[state=active]:bg-[#155dfc]`;
           return (
             <TabsTrigger
               key={segment.value}

--- a/src/components/buttons/SwitchButton.tsx
+++ b/src/components/buttons/SwitchButton.tsx
@@ -3,28 +3,21 @@
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ReactNode } from "react";
 
+export type Segment = {
+  label: string;
+  icon: React.ElementType;
+  value: any;
+};
+
 export default function SwitchButton({
-  leftLabel,
-  rightLabel,
-  leftValue,
-  rightIcon,
-  leftIcon,
-  rightValue,
-  defaultValue = rightValue,
+  segments = [],
+  defaultValue = segments[0]?.value,
   onValueChange,
 }: {
-  leftLabel: string;
-  rightLabel: string;
-  rightIcon: React.ElementType;
-  leftIcon: React.ElementType;
-  leftValue: any;
-  rightValue: any;
+  segments?: Segment[];
   defaultValue?: any;
   onValueChange?: (value: any) => void;
 }) {
-  const IconLeft = leftIcon;
-  const IconRight = rightIcon;
-
   return (
     <Tabs
       defaultValue={defaultValue}
@@ -32,19 +25,22 @@ export default function SwitchButton({
       className="h-[50px] w-full "
     >
       <TabsList className="h-full p-[5px] w-full border border-gray-300 rounded-md">
-        <TabsTrigger
-          className="rounded-sm  text-gray-900 data-[state=inactive]:cursor-pointer data-[state=active]:bg-[#155dfc] data-[state=active]:text-white data-[state=active]:font-medium"
-          value={leftValue}
-        >
-          <IconLeft />
-          {leftLabel}
-        </TabsTrigger>
-        <TabsTrigger
-          className="rounded-sm  text-gray-900 data-[state=inactive]:cursor-pointer data-[state=active]:bg-[#03b703] data-[state=active]:text-white data-[state=active]:font-medium"
-          value={rightValue}
-        >
-          <IconRight /> {rightLabel}
-        </TabsTrigger>
+        {segments.map((segment, idx) => {
+          const Icon = segment.icon;
+          const colors = ["#155dfc", "#03b703"];
+          const activeBg = `data-[state=active]:bg-[${
+            colors[idx % colors.length]
+          }]`;
+          return (
+            <TabsTrigger
+              key={segment.value}
+              className={`rounded-sm text-gray-900 data-[state=inactive]:cursor-pointer data-[state=active]:text-white data-[state=active]:font-medium ${activeBg}`}
+              value={segment.value}
+            >
+              <Icon /> {segment.label}
+            </TabsTrigger>
+          );
+        })}
       </TabsList>
     </Tabs>
   );

--- a/src/components/buttons/SwitchButton.tsx
+++ b/src/components/buttons/SwitchButton.tsx
@@ -29,9 +29,9 @@ export default function SwitchButton({
     <Tabs
       defaultValue={defaultValue}
       onValueChange={onValueChange}
-      className="h-[50px] w-full"
+      className="h-[50px] w-full "
     >
-      <TabsList className="h-full w-full border border-gray-300 rounded-md">
+      <TabsList className="h-full p-[5px] w-full border border-gray-300 rounded-md">
         <TabsTrigger
           className="rounded-sm  text-gray-900 data-[state=inactive]:cursor-pointer data-[state=active]:bg-[#155dfc] data-[state=active]:text-white data-[state=active]:font-medium"
           value={leftValue}

--- a/src/components/buttons/SwitchButton.tsx
+++ b/src/components/buttons/SwitchButton.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { ReactNode } from "react";
+import { SchoolType } from "@/types/basicTypes";
+import { de } from "date-fns/locale";
 
 export type Segment = {
   label: string;
   icon: React.ElementType;
-  value: any;
+  value: SchoolType;
 };
 
 export function SwitchButton({
@@ -15,12 +16,12 @@ export function SwitchButton({
   onValueChange,
 }: {
   segments?: Segment[];
-  defaultValue?: any;
+  defaultValue?: SchoolType;
   onValueChange?: (value: any) => void;
 }) {
   return (
     <Tabs
-      defaultValue={defaultValue}
+      defaultValue={String(defaultValue)}
       onValueChange={onValueChange}
       className="h-[50px] w-full "
     >
@@ -35,7 +36,7 @@ export function SwitchButton({
             <TabsTrigger
               key={segment.value}
               className={`rounded-sm text-gray-900 data-[state=inactive]:cursor-pointer data-[state=active]:text-white data-[state=active]:font-medium ${activeBg}`}
-              value={segment.value}
+              value={String(segment.value)}
             >
               <Icon /> {segment.label}
             </TabsTrigger>

--- a/src/components/buttons/SwitchButton.tsx
+++ b/src/components/buttons/SwitchButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ReactNode } from "react";
 
 export default function SwitchButton({
@@ -13,24 +13,39 @@ export default function SwitchButton({
   defaultValue = rightValue,
   onValueChange,
 }: {
-  leftLabel: string,
-  rightLabel: string,
-  rightIcon: React.ElementType,
-  leftIcon: React.ElementType,
-  leftValue: any
-  rightValue: any
-  defaultValue?: any
-  onValueChange?: (value: string) => void
+  leftLabel: string;
+  rightLabel: string;
+  rightIcon: React.ElementType;
+  leftIcon: React.ElementType;
+  leftValue: any;
+  rightValue: any;
+  defaultValue?: any;
+  onValueChange?: (value: any) => void;
 }) {
   const IconLeft = leftIcon;
   const IconRight = rightIcon;
 
   return (
-    <Tabs defaultValue={defaultValue} onValueChange={onValueChange} className="h-[50px] w-full">
+    <Tabs
+      defaultValue={defaultValue}
+      onValueChange={onValueChange}
+      className="h-[50px] w-full"
+    >
       <TabsList className="h-full w-full border border-gray-300 rounded-md">
-        <TabsTrigger className="rounded-sm  text-gray-900 data-[state=inactive]:cursor-pointer data-[state=active]:bg-[#155dfc] data-[state=active]:text-white data-[state=active]:font-medium" value={leftValue}><IconLeft />{leftLabel}</TabsTrigger>
-        <TabsTrigger className="rounded-sm  text-gray-900 data-[state=inactive]:cursor-pointer data-[state=active]:bg-[#03b703] data-[state=active]:text-white data-[state=active]:font-medium" value={rightValue}><IconRight/> {rightLabel}</TabsTrigger>
+        <TabsTrigger
+          className="rounded-sm  text-gray-900 data-[state=inactive]:cursor-pointer data-[state=active]:bg-[#155dfc] data-[state=active]:text-white data-[state=active]:font-medium"
+          value={leftValue}
+        >
+          <IconLeft />
+          {leftLabel}
+        </TabsTrigger>
+        <TabsTrigger
+          className="rounded-sm  text-gray-900 data-[state=inactive]:cursor-pointer data-[state=active]:bg-[#03b703] data-[state=active]:text-white data-[state=active]:font-medium"
+          value={rightValue}
+        >
+          <IconRight /> {rightLabel}
+        </TabsTrigger>
       </TabsList>
     </Tabs>
-  )
+  );
 }

--- a/src/components/buttons/SwitchButton.tsx
+++ b/src/components/buttons/SwitchButton.tsx
@@ -2,7 +2,6 @@
 
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { SchoolType } from "@/types/basicTypes";
-import { de } from "date-fns/locale";
 
 export type Segment = {
   label: string;

--- a/src/components/publicMap/Help.tsx
+++ b/src/components/publicMap/Help.tsx
@@ -72,13 +72,23 @@ export default function Help({ isOpen, closeModal }: HelpProps) {
                 <P>
                   Mapa zobrazuje přehled spádových oblastí pro největších 300
                   obcí a&nbsp;měst v&nbsp;České republice, které zřizují dvě
-                  a&nbsp;více základních škol a&nbsp;jsou povinny určit jejich
-                  spádovost. V další fázi budou přidány spádové oblasti
-                  mateřských škol.
+                  a&nbsp;více základních či mateřských škol a&nbsp;jsou povinny
+                  určit jejich spádovost.
                 </P>
 
                 <H3>Orientace v mapě</H3>
                 <P>Každá spádová oblast je barevně odlišena:</P>
+                <P>
+                  <Image
+                    src={"/blue_triangle.svg"}
+                    alt="zelený trojúhelník"
+                    width={24}
+                    height={24}
+                    className="inline-block"
+                  />{" "}
+                  <strong>Modrý trojúhelník</strong> - města a obce s již
+                  zpracovanou vyhláškou - mateřské školy.
+                </P>
                 <P>
                   <Image
                     src={"/green_triangle.svg"}
@@ -88,7 +98,7 @@ export default function Help({ isOpen, closeModal }: HelpProps) {
                     className="inline-block"
                   />{" "}
                   <strong>Zelený trojúhelník</strong> - města a obce s již
-                  zpracovanou vyhláškou.
+                  zpracovanou vyhláškou - první stupeň základních škol
                 </P>
                 <P>
                   <Image
@@ -214,7 +224,7 @@ export default function Help({ isOpen, closeModal }: HelpProps) {
                 </P>
 
                 <P>
-                  <em className="text-sm">Verze 1.0 (2024)</em>
+                  <em className="text-sm">Verze 2.0 (2025)</em>
                 </P>
 
                 <div className="mt-4 flex justify-end">

--- a/src/components/publicMap/InnerPublicMap.tsx
+++ b/src/components/publicMap/InnerPublicMap.tsx
@@ -65,9 +65,9 @@ const InnerMap = memo(
           </div>
           <div className="sm:w-fit w-full ">
             <SwitchButton
-              leftLabel="Mateřské Školy"
+              leftLabel={texts.schoolsKindergarten}
               leftIcon={PuzzlePieceIcon}
-              rightLabel="Základní Školy"
+              rightLabel={texts.schoolsElementary}
               rightIcon={AcademicCapIcon}
               defaultValue={schoolType}
               leftValue={SchoolType.Kindergarten}

--- a/src/components/publicMap/InnerPublicMap.tsx
+++ b/src/components/publicMap/InnerPublicMap.tsx
@@ -44,7 +44,7 @@ const InnerMap = memo(
       }
     }, [cities, schoolType, mapRef]);
 
-    const handleChange = (value: any) => {
+    const handleChange = (value: SchoolType) => {
       if (value === SchoolType.Elementary) {
         window.location.href = "/zs";
       } else {

--- a/src/components/publicMap/InnerPublicMap.tsx
+++ b/src/components/publicMap/InnerPublicMap.tsx
@@ -15,10 +15,7 @@ import { Menu } from "./Menu";
 import SwitchButton from "../buttons/SwitchButton";
 import { SchoolType } from "@/types/basicTypes";
 import { useRouter } from "next/navigation";
-import {
-  AcademicCapIcon,
-  PuzzlePieceIcon,
-} from "@heroicons/react/24/solid";
+import { AcademicCapIcon, PuzzlePieceIcon } from "@heroicons/react/24/solid";
 
 interface InnerPublicMapProps {
   cities: CityOnMap[];
@@ -27,7 +24,6 @@ interface InnerPublicMapProps {
 
 const InnerMap = memo(
   ({ cities, schoolType }: InnerPublicMapProps) => {
-    const router = useRouter()
     const mapRef = useRef<HTMLDivElement>(null);
     const [onSelect, setOnSelect] = useState<(item: SuggestionItem) => void>(
       () => () => {}
@@ -49,17 +45,16 @@ const InnerMap = memo(
     }, [cities, schoolType, mapRef]);
 
     const handleChange = (value: any) => {
-      if(value === SchoolType.Elementary) {
-        router.push('/zs')
-      }else {
-        router.push('/ms')
+      if (value === SchoolType.Elementary) {
+        window.location.href = "/zs";
+      } else {
+        window.location.href = "/ms";
       }
     };
 
     return (
       <>
         <div ref={mapRef} className="h-screen w-screen" />
-
 
         <div className="absolute top-[10px] px-2.5 z-1000 flex justify-between items-center gap-2.5 w-full md:max-w-[calc(100vw-260px)] flex-wrap">
           <div className="flex items-center gap-2.5 w-full sm:w-fit">
@@ -69,7 +64,16 @@ const InnerMap = memo(
             </div>
           </div>
           <div className="sm:w-fit w-full ">
-            <SwitchButton leftLabel="Mateřské Školy" leftIcon={PuzzlePieceIcon} rightLabel="Základní Školy" rightIcon={AcademicCapIcon} defaultValue={schoolType} leftValue={SchoolType.Kindergarten} rightValue={SchoolType.Elementary} onValueChange={(value) => handleChange(value)} />
+            <SwitchButton
+              leftLabel="Mateřské Školy"
+              leftIcon={PuzzlePieceIcon}
+              rightLabel="Základní Školy"
+              rightIcon={AcademicCapIcon}
+              defaultValue={schoolType}
+              leftValue={SchoolType.Kindergarten}
+              rightValue={SchoolType.Elementary}
+              onValueChange={(value) => handleChange(value)}
+            />
           </div>
           <div></div>
         </div>
@@ -80,7 +84,6 @@ const InnerMap = memo(
         <div className="absolute top-[10px] left-[70px] z-1000 w-[min(430px,calc(100vw-80px))]">
           <SearchInput onSelect={onSelect} />
         </div> */}
-
 
         <div
           className="absolute z-1000 bottom-0 left-0

--- a/src/components/publicMap/InnerPublicMap.tsx
+++ b/src/components/publicMap/InnerPublicMap.tsx
@@ -65,14 +65,20 @@ const InnerMap = memo(
           </div>
           <div className="sm:w-fit w-full ">
             <SwitchButton
-              leftLabel={texts.schoolsKindergarten}
-              leftIcon={PuzzlePieceIcon}
-              rightLabel={texts.schoolsElementary}
-              rightIcon={AcademicCapIcon}
+              segments={[
+                {
+                  label: texts.schoolsKindergarten,
+                  icon: PuzzlePieceIcon,
+                  value: SchoolType.Kindergarten,
+                },
+                {
+                  label: texts.schoolsElementary,
+                  icon: AcademicCapIcon,
+                  value: SchoolType.Elementary,
+                },
+              ]}
               defaultValue={schoolType}
-              leftValue={SchoolType.Kindergarten}
-              rightValue={SchoolType.Elementary}
-              onValueChange={(value) => handleChange(value)}
+              onValueChange={handleChange}
             />
           </div>
           <div></div>

--- a/src/components/publicMap/InnerPublicMap.tsx
+++ b/src/components/publicMap/InnerPublicMap.tsx
@@ -12,7 +12,7 @@ import { texts } from "../../utils/shared/texts";
 import PublicButton from "../buttons/PublicButton";
 import { SearchInput } from "./SearchInput";
 import { Menu } from "./Menu";
-import SwitchButton from "../buttons/SwitchButton";
+import { SwitchButton } from "../buttons/SwitchButton";
 import { SchoolType } from "@/types/basicTypes";
 import { useRouter } from "next/navigation";
 import { AcademicCapIcon, PuzzlePieceIcon } from "@heroicons/react/24/solid";

--- a/src/components/publicMap/Intro.tsx
+++ b/src/components/publicMap/Intro.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import { Fragment } from "react";
 import PublicButton from "../buttons/PublicButton";
 import CloseModalButton from "./CloseModalButton";
+import { H3, P } from "./Typography";
 
 type IntroProps = {
   closeModal: () => void;
@@ -44,11 +45,49 @@ export default function Intro({ isOpen, closeModal }: IntroProps) {
                 >
                   Vítejte v mapě spádovosti
                 </Dialog.Title>
-                <p className="pb-8">
-                  Tato aplikace vám pomůže jednoduše zjistit spádovou školu dle
-                  vaší adresy. Aktuálně zobrazuje spádovost základních škol v
-                  300 největších městech ČR.
-                </p>
+                <P>
+                  Mapa zobrazuje přehled spádových oblastí pro největších 300
+                  obcí a&nbsp;měst v&nbsp;České republice, které zřizují dvě
+                  a&nbsp;více základních či mateřských škol a&nbsp;jsou povinny
+                  určit jejich spádovost.
+                </P>
+
+                <H3>Orientace v mapě</H3>
+                <P>Každá spádová oblast je barevně odlišena:</P>
+                <P>
+                  <Image
+                    src={"/blue_triangle.svg"}
+                    alt="zelený trojúhelník"
+                    width={24}
+                    height={24}
+                    className="inline-block"
+                  />{" "}
+                  <strong>Modrý trojúhelník</strong> - města a obce s již
+                  zpracovanou vyhláškou - mateřské školy.
+                </P>
+                <P>
+                  <Image
+                    src={"/green_triangle.svg"}
+                    alt="zelený trojúhelník"
+                    width={24}
+                    height={24}
+                    className="inline-block"
+                  />{" "}
+                  <strong>Zelený trojúhelník</strong> - města a obce s již
+                  zpracovanou vyhláškou - první stupeň základních škol
+                </P>
+                <P>
+                  <Image
+                    src={"/grey_triangle.svg"}
+                    alt="zelený trojúhelník"
+                    width={24}
+                    height={24}
+                    className="inline-block"
+                  />{" "}
+                  <strong>Šedý trojúhelník</strong> - města a obce čekající na
+                  zpracování.
+                </P>
+                <H3>Ovladací prvky</H3>
                 <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 items-baseline">
                   <Image
                     src={"/intro-search.png"}

--- a/src/controllers/FounderController.ts
+++ b/src/controllers/FounderController.ts
@@ -80,6 +80,7 @@ export class FounderController {
       schoolsByCity.get(city)!.push({
         izo: school.izo,
         name: school.name,
+        type: school.type,
       });
     }
 

--- a/src/controllers/OrdinanceControllerServer.ts
+++ b/src/controllers/OrdinanceControllerServer.ts
@@ -17,7 +17,8 @@ export class OrdinanceControllerServer {
   }
 
   static async getActiveOrdinanceBySchoolIzo(
-    schoolIzo: string
+    schoolIzo: string,
+    schoolType: SchoolType = SchoolType.Elementary
   ): Promise<{ cityCode: number; ordinanceId: number } | null> {
     const knex = KnexDataProvider.getDb();
 
@@ -26,8 +27,9 @@ export class OrdinanceControllerServer {
         `SELECT f.city_code, o.id AS ordinance_id FROM school_founder sf
         JOIN founder f ON sf.founder_id = f.id
         JOIN ordinance o ON f.city_code = o.city_code
-        WHERE sf.school_izo = ? AND o.is_active = 1`,
-        [schoolIzo]
+        WHERE sf.school_izo = ? AND o.is_active = 1 AND o.school_type = ?`,
+
+        [schoolIzo, schoolType]
       )
     )[0]?.[0];
 

--- a/src/entities/School.ts
+++ b/src/entities/School.ts
@@ -20,7 +20,7 @@ export class School {
   @Fields.integer()
   capacity = 0;
 
-  @Fields.object({ dbName: "type" })
+  @Fields.integer({ dbName: "type" })
   type = SchoolType.Elementary;
 }
 
@@ -51,5 +51,5 @@ export const getRootPathBySchoolType = (
       ? routes.shortKindergarten
       : routes.kindergarten
     : short
-      ? routes.shortElementary
-      : routes.elementary;
+    ? routes.shortElementary
+    : routes.elementary;

--- a/src/types/embed.ts
+++ b/src/types/embed.ts
@@ -1,8 +1,10 @@
+import { SchoolType } from "@/types/basicTypes";
+
 export type CitySchools = {
   cityName: string;
   schools: School[];
 };
 
-export type School = { izo: string; name: string };
+export type School = { izo: string; name: string; type: SchoolType };
 
 export type City = { code: number; name: string };

--- a/src/utils/server/textToMap.ts
+++ b/src/utils/server/textToMap.ts
@@ -125,8 +125,12 @@ export async function getOrCreateDataForMapBySchoolIzo(
   const school = await remult.repo(School).findFirst({
     izo: schoolIzo,
   });
+
   const activeOrdinance =
-    await OrdinanceControllerServer.getActiveOrdinanceBySchoolIzo(schoolIzo);
+    await OrdinanceControllerServer.getActiveOrdinanceBySchoolIzo(
+      schoolIzo,
+      school.type
+    );
 
   if (activeOrdinance === null) {
     return null;
@@ -163,13 +167,15 @@ export async function getOrCreateDataForMapByCityCode(
 
   let jsonData = mapData?.jsonData ?? null;
   let polygons = mapData?.polygons ?? null;
-
+  // console.log("jsonData", jsonData);
   if (jsonData === null) {
     if (smdTexts.length === 0) {
       console.log(`No street markdowns found for city code = '${cityCode}'.`);
       return null;
     }
+
     jsonData = await getAddressPointsBySmdTexts(smdTexts, schoolType);
+
     if (jsonData === null) {
       return null;
     }
@@ -293,6 +299,7 @@ async function filterSchoolData(
   schoolIzo: string
 ): Promise<DataForMap | null> {
   // filter municipalities
+
   const municipalities = data.municipalities
     .filter((municipality) =>
       municipality.areas.some((area) =>

--- a/src/utils/server/textToMap.ts
+++ b/src/utils/server/textToMap.ts
@@ -167,7 +167,7 @@ export async function getOrCreateDataForMapByCityCode(
 
   let jsonData = mapData?.jsonData ?? null;
   let polygons = mapData?.polygons ?? null;
-  // console.log("jsonData", jsonData);
+
   if (jsonData === null) {
     if (smdTexts.length === 0) {
       console.log(`No street markdowns found for city code = '${cityCode}'.`);


### PR DESCRIPTION
This PR adds a switch button to the public routes, allowing users to switch between elementary schools and kindergartens in /zs, /ms, /data, and /embed. It also includes changes to the logic for rendering school-type selected data in /m and /s.

For some reason, I'm occasionally getting an SQLITE_ERROR when map data is being rendered. I'm not sure whether it's due to a mistake I haven't found yet or  some mismatch in data. Could you take a look into it? Here's the error:

```
SqliteError: select `f`.`id`, `f`.`name`, `f`.`ico`, `f`.`founder_type_code`, `f`.`city_code`, `f`.`city_district_code` from `founder` as `f` left join `city` as `c` on `c`.`code` = `f`.`city_code` left join `city_district` as `d` on `d`.`code` = `f`.`city_district_code` where `f`.`id` = 884 order by `f`.`founder_type_code` asc limit 1 - no such table: founder

Call stack:
    at async getAddressPointsBySmdTexts (/src/utils/server/textToMap.ts:384:8)
    at async getOrCreateDataForMapByCityCode (/src/utils/server/textToMap.ts:177:15)
    at async getOrCreateDataForMapByCityCodes (/src/utils/server/textToMap.ts:102:17)
    at async POST (/src/app/api/map/municipalities/route.ts:14:32)
```